### PR TITLE
Better method of comparing float64

### DIFF
--- a/testx.go
+++ b/testx.go
@@ -8,15 +8,14 @@ package testx
 
 import (
 	"fmt"
+	"math"
 	"testing"
 )
 
-// Tolerance adjust the accuracy of the function.
-const tolerance float64 = 0.00000001
-
 // EqualFloat tests the expected with the actual value.
 func EqualFloat(t *testing.T, expected, actual float64, msg string) {
-	if !((expected-actual) < tolerance && (actual-expected) < tolerance) {
+	maxmul := math.Max(1.0, math.Max(expected, actual))
+	if math.Abs(expected-actual) > (math.SmallestNonzeroFloat64 * maxmul) {
 		t.Errorf(fmt.Sprintf("%s not equal.\n"+
 			"expected: %g\n"+
 			"actual  : %g", msg, expected, actual))

--- a/testx_test.go
+++ b/testx_test.go
@@ -1,0 +1,21 @@
+package testx
+
+import "testing"
+
+func TestA(t *testing.T) {
+	cases := []struct {
+		a, b float64
+		msg  string
+	}{
+		{1.0000000000000000000001, 0.999999999999999999999999999998, "hmmmm..."},
+		{10000000000000.0, 10000000000000.0, "large float"},
+		{1.0e48, 1.0e48, "large float 2"},
+		{1.1, 1.1, "medium sized float 1"},
+		{1.121212121212121212, 1.121212121212121212, "medium sized float 2"},
+		{0.0000000000000000000000000000000000000000001, 0.0000000000000000000000000000000000000000001, "smaller float"},
+		{4.123 + 2.3 * 4.3 / 2.3, 4.3 / 2.3 * 2.3 + 4.123, "some calc"},
+	}
+	for _, c := range cases {
+		EqualFloat(t, c.a, c.b, c.msg)
+	}
+}


### PR DESCRIPTION
by using the smallest float64 (epsilon) of the standard library.
Inspired by [this Stackoverflow question](https://stackoverflow.com/questions/4548004/how-to-correctly-and-standardly-compare-floats)